### PR TITLE
Make the user's gid have the same name as the user

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,7 +108,7 @@ class gitolite (
         require  => Group[$gitolite::user],
         ensure   => "present",
         comment  => "Gitolite Hosting",
-        gid      => "gitolite",
+        gid      => $gitolite::user,
         home     => $gitolite::homedir,
         password => $gitolite::password,
         system   => true;


### PR DESCRIPTION
Right now even though the a group is created that's name is derived from the desired user, the gid for the user is still statically set to be "gitolite". This corrects it to being $gitolite::user
