### PR TITLE
Fix gitolite.rc config bug and add ability to manager user creation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,6 +6,9 @@ This module automatically installs [gitolite](http://sitaramc.github.com/gitolit
 
 ## Parameters:
 
+
+* `manage_user`
+  whether to manage gitolite user (default "true")
 * `user`  
   name of gitolite management user (default "gitolite")  
 * `password`  

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@
 #
 # Parameters:
 #
+#   manage_user: Create gitolite management user and group (default "true")
 #   user: name of gitolite management user (default "gitolite")
 #   password: HASHED (not plain-text) password of gitolite management user
 #   homedir: home directory of gitolite management user
@@ -51,6 +52,7 @@
 # [Remember: No empty lines between comments and class definition]
 class gitolite (
   $keycontent,
+  $manage_user     = $gitolite::params::manage_user,
   $password        = $gitolite::params::password,
   $user            = $gitolite::params::user,
   $homedir         = $gitolite::params::homedir,
@@ -112,7 +114,7 @@ class gitolite (
     }
   }
 
-  if $gitolite::password != 'undef'{
+  if $manage_user and $gitolite::password != 'undef'{
     group {
       $gitolite::user:
         ensure => "present";

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,7 @@
 #default params for gitolite module and it's classes
 class gitolite::params {
   $password         = 'undef'
+  $manage_user      = true
   $user             = "gitolite"
   $homedir          = "/var/gitolite"
   $source           = "http://github.com/sitaramc/gitolite.git"

--- a/manifests/rc.pp
+++ b/manifests/rc.pp
@@ -23,12 +23,13 @@ class gitolite::rc(
   $post_create     = $gitolite::params::post_create,
   $post_compile    = $gitolite::params::post_compile,
 ) inherits gitolite::params {
-  
+
   file { "${gitolite::homedir}/.gitolite.rc":
-    ensure  => file,
-    owner   => $gitolite::user,
-    group   => $gitolite::user,
-    content => template('gitolite/gitolite3.rc.erb'),
-    mode    => '644',
+    ensure   => file,
+    owner    => $gitolite::user,
+    group    => $gitolite::user,
+    content  => template('gitolite/gitolite3.rc.erb'),
+    mode     => '644',
   }
+
 }

--- a/templates/gitolite3.rc.erb
+++ b/templates/gitolite3.rc.erb
@@ -1,0 +1,195 @@
+# configuration variables for gitolite
+
+# This file is in perl syntax.  But you do NOT need to know perl to edit it --
+# just mind the commas, use single quotes unless you know what you're doing,
+# and make sure the brackets and braces stay matched up!
+
+# (Tip: perl allows a comma after the last item in a list also!)
+
+# HELP for commands can be had by running the command with "-h".
+
+# HELP for all the other FEATURES can be found in the documentation (look for
+# "list of non-core programs shipped with gitolite" in the master index) or
+# directly in the corresponding source file.
+
+%RC = (
+
+    # ------------------------------------------------------------------
+
+    # default umask gives you perms of '0700'; see the rc file docs for
+    # how/why you might change this
+    UMASK                           =>  0077,
+
+    # look for "git-config" in the documentation
+    GIT_CONFIG_KEYS                 =>  '<%= @git_config_keys %>',
+
+    # comment out if you don't need all the extra detail in the logfile
+    LOG_EXTRA                       =>  1,
+    # syslog options
+    # 1. leave this section as is for normal gitolite logging
+    # 2. uncomment this line to log only to syslog:
+    # LOG_DEST                      => 'syslog',
+    # 3. uncomment this line to log to syslog and the normal gitolite log:
+    # LOG_DEST                      => 'syslog,normal',
+
+    # roles.  add more roles (like MANAGER, TESTER, ...) here.
+    #   WARNING: if you make changes to this hash, you MUST run 'gitolite
+    #   compile' afterward, and possibly also 'gitolite trigger POST_COMPILE'
+    ROLES => {
+        READERS                     =>  1,
+        WRITERS                     =>  1,
+    },
+
+    # enable caching (currently only Redis).  PLEASE RTFM BEFORE USING!!!
+    # CACHE                         =>  'Redis',
+
+    # ------------------------------------------------------------------
+
+    # rc variables used by various features
+
+    # the 'info' command prints this as additional info, if it is set
+        # SITE_INFO                 =>  'Please see http://blahblah/gitolite for more help',
+
+    # the CpuTime feature uses these
+        # display user, system, and elapsed times to user after each git operation
+        # DISPLAY_CPU_TIME          =>  1,
+        # display a warning if total CPU times (u, s, cu, cs) crosses this limit
+        # CPU_TIME_WARN_LIMIT       =>  0.1,
+
+    # the Mirroring feature needs this
+        # HOSTNAME                  =>  "foo",
+
+    # TTL for redis cache; PLEASE SEE DOCUMENTATION BEFORE UNCOMMENTING!
+        # CACHE_TTL                 =>  600,
+
+    # ------------------------------------------------------------------
+
+    # suggested locations for site-local gitolite code (see cust.html)
+
+        # this one is managed directly on the server
+        # LOCAL_CODE                =>  "$ENV{HOME}/local",
+
+        # or you can use this, which lets you put everything in a subdirectory
+        # called "local" in your gitolite-admin repo.  For a SECURITY WARNING
+        # on this, see http://gitolite.com/gitolite/non-core.html#pushcode
+        # LOCAL_CODE                =>  "$rc{GL_ADMIN_BASE}/local",
+
+    # ------------------------------------------------------------------
+
+    # List of commands and features to enable
+
+    ENABLE => [
+
+        # COMMANDS
+
+            # These are the commands enabled by default
+            'help',
+            'desc',
+            'info',
+            'perms',
+            'writable',
+
+            # Uncomment or add new commands here.
+            # 'create',
+            # 'fork',
+            # 'mirror',
+            # 'readme',
+            # 'sskm',
+            # 'D',
+
+        # These FEATURES are enabled by default.
+
+            # essential (unless you're using smart-http mode)
+            'ssh-authkeys',
+
+            # creates git-config enties from gitolite.conf file entries like 'config foo.bar = baz'
+            'git-config',
+
+            # creates git-daemon-export-ok files; if you don't use git-daemon, comment this out
+            'daemon',
+
+            # creates projects.list file; if you don't use gitweb, comment this out
+            'gitweb',
+
+        # These FEATURES are disabled by default; uncomment to enable.  If you
+        # need to add new ones, ask on the mailing list :-)
+
+        # user-visible behaviour
+
+            # prevent wild repos auto-create on fetch/clone
+            # 'no-create-on-read',
+            # no auto-create at all (don't forget to enable the 'create' command!)
+            # 'no-auto-create',
+
+            # access a repo by another (possibly legacy) name
+            # 'Alias',
+
+            # give some users direct shell access.  See documentation in
+            # sts.html for details on the following two choices.
+            # "Shell $ENV{HOME}/.gitolite.shell-users",
+            # 'Shell alice bob',
+
+            # set default roles from lines like 'option default.roles-1 = ...', etc.
+            # 'set-default-roles',
+
+            # show more detailed messages on deny
+            # 'expand-deny-messages',
+
+            # show a message of the day
+            # 'Motd',
+
+        # system admin stuff
+
+            # enable mirroring (don't forget to set the HOSTNAME too!)
+            # 'Mirroring',
+
+            # allow people to submit pub files with more than one key in them
+            # 'ssh-authkeys-split',
+
+            # selective read control hack
+            # 'partial-copy',
+
+            # manage local, gitolite-controlled, copies of read-only upstream repos
+            # 'upstream',
+
+            # updates 'description' file instead of 'gitweb.description' config item
+            # 'cgit',
+
+            # allow repo-specific hooks to be added
+            # 'repo-specific-hooks',
+
+        # performance, logging, monitoring...
+
+            # be nice
+            # 'renice 10',
+
+            # log CPU times (user, system, cumulative user, cumulative system)
+            # 'CpuTime',
+
+        # syntactic_sugar for gitolite.conf and included files
+
+            # allow backslash-escaped continuation lines in gitolite.conf
+            # 'continuation-lines',
+
+            # create implicit user groups from directory names in keydir/
+            # 'keysubdirs-as-groups',
+
+            # allow simple line-oriented macros
+            # 'macros',
+
+        # Kindergarten mode
+
+            # disallow various things that sensible people shouldn't be doing anyway
+            # 'Kindergarten',
+    ],
+
+);
+
+# ------------------------------------------------------------------------------
+# per perl rules, this should be the last line in such a file:
+1;
+
+# Local variables:
+# mode: perl
+# End:
+# vim: set syn=perl:


### PR DESCRIPTION
Two commits here:
- 351ac05 adds support for managing user/group creation, which is useful for cases (such as mine) where git user is managed outside the module (without this bit, the module errors out if git user already exists)
- b9dd428 fixes bug #14 filed by @hesco
